### PR TITLE
Enhance missing assignments searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .env
 .venv
-*.txt

--- a/README.en.md
+++ b/README.en.md
@@ -4,8 +4,8 @@
 
 Simple script to **remind** any missing assignment in **Moodle**. Written in Python using [Selenium](https://www.selenium.dev/).
 
-> [!NOTE]
-> IDs are hardcoded for my current subjects :rofl:
+> [!IMPORTANT]
+> Timeline must be enabled! If you don't have it, you have to enable it manually. In the future it will be enabled automatically.
 
 ## 🏡 Setup
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Simple script para **recordar** cualquier asignatura que falte por entregar en **Moodle**. Escrito en Python usando [Selenium](https://www.selenium.dev/).
 
-> [!NOTE]
-> Los IDS están hardcodeados para mis asignaturas :rofl:
+> [!IMPORTANT]
+> ¡La Línea de tiempo debe estar activada! Si no lo tienes, lo tienes que activar manualmente. En el futuro será activado automáticamente.
 
 ## 🏡 Setup
 

--- a/blacklist.txt
+++ b/blacklist.txt
@@ -1,0 +1,3 @@
+Control de versiones
+Planificación de procesos
+RECUPERACIÓN PRIMER TRIMESTRE

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from colorama import init, Fore, Style
 from dotenv import load_dotenv
+from time import sleep
 import os
 import sys
 
@@ -48,27 +49,63 @@ def login(driver, username, password):
     login_btn = driver.find_element(By.CLASS_NAME, "btn-submit")
     login_btn.click()
 
+#def get_missing_assignments(driver, blacklist_filename):
+#    log_info("Getting missing assignments...")
+#    subject_url = "https://educacionadistancia.juntadeandalucia.es/centros/malaga/mod/assign/index.php?id="
+#    try:
+#        blacklist = (''.join(open(blacklist_filename, 'r')).lower()).split('\n')
+#        blacklist.pop(len(blacklist) - 1)
+#    except Exception as e:
+#        blacklist = []
+#    ids = {9051: "Sostenibilidad", 4011: "BBDD", 6585: "Entornos", 6584: "LDM", 4162: "Digitalización", 4161: "IPE", 4008: "Programación", 4000: "Sistemas"}
+#    assignments = []
+#
+#    for key in ids:
+#        driver.get(subject_url + str(key))
+#        wait = WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "generaltable")))
+#
+#        table = driver.find_element(By.CLASS_NAME, "generaltable")
+#        rows = table.find_elements(By.XPATH, ".//tr")
+#        for row in rows:
+#            if any(x in row.text.lower() for x in blacklist) or "no entregado" not in row.text.lower():
+#                continue
+#            assignments.append({ids[key]: row.text})
+#            print(f"{Fore.YELLOW}{ids[key]}: {Style.RESET_ALL}{row.text}")
+#
+#    return assignments
+
 def get_missing_assignments(driver, blacklist_filename):
     log_info("Getting missing assignments...")
-    subject_url = "https://educacionadistancia.juntadeandalucia.es/centros/malaga/mod/assign/index.php?id="
-    blacklist = (''.join(open(blacklist_filename, 'r')).lower()).split('\n')
-    blacklist.pop(len(blacklist) - 1)
-    ids = {9051: "Sostenibilidad", 4011: "BBDD", 6585: "Entornos", 6584: "LDM", 4162: "Digitalización", 4161: "IPE", 4008: "Programación", 4000: "Sistemas"}
-    assignments = []
+    menu = "https://educacionadistancia.juntadeandalucia.es/centros/malaga/my/"
+    driver.get(menu)
+    wait = WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "card-body")))
+    divs = driver.find_elements(By.CLASS_NAME, "card-body")
+    has_timeline = False
+    timeline_div = None
+    for div in divs:
+        try:
+            title = div.find_element(By.TAG_NAME, "h3")
+            if title.text == "Línea de tiempo":
+                has_timeline = True
+                timeline_div = div
+                break
+        except:
+            pass
 
-    for key in ids:
-        driver.get(subject_url + str(key))
-        wait = WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "generaltable")))
+    if has_timeline:
+        wait = WebDriverWait(driver, 20).until(EC.element_to_be_clickable((By.XPATH, "//button[contains(text(), 'Mostrar más actividades')]")))
+        try:
+            while True:
+                button = driver.find_element(By.XPATH, "//button[contains(text(), 'Mostrar más actividades')]")
+                button.click()
+                sleep(3)
+        except:
+            pass
 
-        table = driver.find_element(By.CLASS_NAME, "generaltable")
-        rows = table.find_elements(By.XPATH, ".//tr")
-        for row in rows:
-            if any(x in row.text.lower() for x in blacklist) or "no entregado" not in row.text.lower():
-                continue
-            assignments.append({ids[key]: row.text})
-            print(f"{Fore.YELLOW}{ids[key]}: {Style.RESET_ALL}{row.text}")
+        anchors = driver.find_elements(By.XPATH, ".//a[contains(@title, 'Vencimiento')]")
+        for anchor in anchors:
+            print(anchor.text)
 
-    return assignments
 
 if __name__ == "__main__":
     blacklist_filename = "blacklist.txt"

--- a/main.py
+++ b/main.py
@@ -29,18 +29,9 @@ def parse_env(env_var):
     return parsed_data
 
 def setup_driver():
-    dev_flag = False
-
-    if dev_flag:
-        # I still have to figure out a global way to do it, maybe installing a browser locally
-        options = webdriver.FirefoxOptions()
-        options.browser_location = "/usr/bin/firefox"
-        options.add_argument("--headless")
-        driver = webdriver.Firefox(options=options)
-    else:
-        options = webdriver.ChromeOptions()
-        options.add_argument("--headless=new")
-        driver = webdriver.Chrome(options=options)
+    options = webdriver.ChromeOptions()
+    options.add_argument("--headless=new")
+    driver = webdriver.Chrome(options=options)
 
     return driver
 


### PR DESCRIPTION
Instead of searching for every subject and retrieving the missing assignments, use the Timeline feature, reducing the searching time from ~2min to ~20s.

I would like to automate enabling the Timeline in case it isn't enabled before merging. But if it is enabled, this branch is safe to use.